### PR TITLE
Fix logout on remember

### DIFF
--- a/starlette_login/utils.py
+++ b/starlette_login/utils.py
@@ -61,7 +61,7 @@ async def logout_user(request: Request) -> None:
     if session_id in request.session:
         request.session.pop(session_id)
 
-    if remember_cookie in request.cookies:
+    if remember_cookie in request.session:
         request.session[remember_cookie] = "clear"
         if remember_seconds in request.session:
             request.session.pop(remember_seconds)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import pytest
-
 from starlette_login.utils import decode_cookie, encode_cookie
 
 SECRET_KEY = "secret"
@@ -57,6 +56,22 @@ class TestLogin:
 
         assert resp.status_code == 200
         assert data["session"]["_remember"] == "set"
+
+    async def test_logout_w_remember_me(self, test_client):
+        _ = test_client.post(
+            "/login",
+            data={
+                "username": "user1",
+                "password": "password",
+                "remember": True,
+            },
+        )
+        resp = test_client.get("/protected")
+        assert resp.status_code == 200
+
+        _ = test_client.get("/logout")
+        resp = test_client.get("/protected", follow_redirects=False)
+        assert resp.status_code == 302
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`logout_user(request)` was not working in the face of `login_user(..., remember=True)`. I was able to trace it to a simple typo in `logout_user`. This PR adds a failing test and a fix that addresses the bug.

Note: I've tested against Starlette 0.24.0 on python 3.11, which was the version current back in February at the last release of Starlette-Login. (There are some other, seemingly-unrelated test failures in `test_decorator.py` against 0.24.0) There are quite a few test failures against the latest Starlette (currently 0.31.1).